### PR TITLE
use actual keys for json parsing

### DIFF
--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -35,10 +35,10 @@ for (var i = 1; i <= 12; i++) {
 }
 
 function onDataReceived(data) {
-    productEngineeringIS24.push(data.productEngineeringIS24);
-    productEngineeringAS24.push(data.productEngineeringAS24);
-    platformEngineering.push(data.platformEngineering);
-    dataEngineering.push(data.dataEngineering);
+    productEngineeringIS24.push(data.product_engineering_is24);
+    productEngineeringAS24.push(data.product_engineering_as24);
+    platformEngineering.push(data.platform_engineering);
+    dataEngineering.push(data.data_engineering);
     total.push(data.total);
 }
 


### PR DESCRIPTION
Hi Christin, leider darf ich nicht in das Original pushen.
Das Dashboard ist gerade kaputt, weil das "echte" json andere keys verwendet. Mein change fixed das.